### PR TITLE
Fix missing confirmation dialogs

### DIFF
--- a/deployment-ui/src/RoutingControlScreen.tsx
+++ b/deployment-ui/src/RoutingControlScreen.tsx
@@ -274,7 +274,7 @@ export default function RoutingControlScreen() {
                 variant="contained"
                 color="success"
                 startIcon={<SwapHorizIcon />}
-                onClick={handleSwitchAllToGreen}
+                onClick={() => setConfirmOpen(true)}
                 sx={{ minWidth: 180 }}
               >
                 Switch All Traffic to Green
@@ -287,7 +287,7 @@ export default function RoutingControlScreen() {
                 variant="outlined"
                 color="primary"
                 startIcon={<UndoIcon />}
-                onClick={handleRollbackToBlue}
+                onClick={() => setRollbackOpen(true)}
                 disabled={defaultRoute === 'blue'}
                 sx={{ minWidth: 160 }}
               >


### PR DESCRIPTION
## Summary
- show the confirmation dialogs in RoutingControlScreen before switching traffic or rolling back

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd2ef7ee08332a2a8c377b47d88e5