### PR TITLE
Fix JWT parsing in UI

### DIFF
--- a/deployment-ui/src/App.tsx
+++ b/deployment-ui/src/App.tsx
@@ -19,8 +19,9 @@ function parseJwt(token: string): { sub?: string; aud?: string | string[] } {
   try {
     const base64Url = token.split('.')[1];
     const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = base64.padEnd(base64.length + (4 - base64.length % 4) % 4, '=');
     const jsonPayload = decodeURIComponent(
-      atob(base64)
+      atob(padded)
         .split('')
         .map(function (c) {
           return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);


### PR DESCRIPTION
## Summary
- correctly pad base64 JWT segment before decoding

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd46e4e808332a62e05fafe79f920